### PR TITLE
Improvement compiler

### DIFF
--- a/src/main/java/br/ifmath/compiler/App.java
+++ b/src/main/java/br/ifmath/compiler/App.java
@@ -1,8 +1,8 @@
 package br.ifmath.compiler;
 
-import br.ifmath.compiler.application.ICompiler;
 
 import br.ifmath.compiler.application.Compiler;
+import br.ifmath.compiler.application.ICompiler;
 import br.ifmath.compiler.domain.expertsystem.AnswerType;
 import br.ifmath.compiler.domain.expertsystem.IAnswer;
 import br.ifmath.compiler.domain.expertsystem.IExpertSystem;
@@ -17,6 +17,38 @@ import br.ifmath.compiler.domain.expertsystem.linearequation.LinearEquationExper
 public class App 
 {
     public static void main( String[] args ) {
-
+        String[] expressions = new String[] {
+            //"y+2=2y-4",
+            "x+3*(-10)=-x",
+            //"x+3*(-10x)=-1",
+        };
+        
+        ICompiler compiler = new Compiler();
+        IExpertSystem expertSystem = new LinearEquationExpertSystem();
+        for (String expression : expressions) {
+            System.out.println("===========================================================================================");
+            System.out.println(String.format("\nExpressão: %s", expression));
+            
+            try {
+                IAnswer answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
+                
+                for (Step step : answer.getSteps()) {
+                    System.out.println("NOTAÇÃO MATEMÁTICA......: " + step.getMathExpression());
+                    System.out.println("NOTAÇÃO LaTeX...........: " + step.getLatexExpression());
+                    System.out.println("JUSTIFICATIVA...........: " + step.getReason());
+                    System.out.println();
+                }
+                
+                System.out.println();
+                System.out.println("A.....: " + ((AnswerLinearEquation) answer).getA());
+                System.out.println("B.....: " + ((AnswerLinearEquation) answer).getB());
+                System.out.println("X.....: " + ((AnswerLinearEquation) answer).getX());
+                
+                System.out.println(String.format("A expressão %s é válida!", expression));
+            } catch (Exception e) {
+                System.out.println(String.format("A expressão %s é inválida! Mensagem de erro: %s", expression, e.getMessage()));
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/java/br/ifmath/compiler/App.java
+++ b/src/main/java/br/ifmath/compiler/App.java
@@ -17,11 +17,7 @@ import br.ifmath.compiler.domain.expertsystem.linearequation.LinearEquationExper
 public class App 
 {
     public static void main( String[] args ) {
-        String[] expressions = new String[] {
-            //"y+2=2y-4",
-            "x+3*(-10)=-x",
-            //"x+3*(-10x)=-1",
-        };
+        String[] expressions = new String[] {};
         
         ICompiler compiler = new Compiler();
         IExpertSystem expertSystem = new LinearEquationExpertSystem();

--- a/src/main/java/br/ifmath/compiler/application/Compiler.java
+++ b/src/main/java/br/ifmath/compiler/application/Compiler.java
@@ -7,7 +7,6 @@ import br.ifmath.compiler.domain.expertsystem.IAnswer;
 import br.ifmath.compiler.domain.expertsystem.IExpertSystem;
 import br.ifmath.compiler.domain.expertsystem.InvalidAlgebraicExpressionException;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.InvalidDistributiveOperationException;
 import br.ifmath.compiler.domain.grammar.nonterminal.E;
 import br.ifmath.compiler.domain.grammar.nonterminal.UnrecognizedStructureException;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
@@ -16,9 +15,9 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 import br.ifmath.compiler.infrastructure.compiler.iface.ILexicalAnalyzer;
 import br.ifmath.compiler.infrastructure.compiler.iface.ISymbolTable;
 import br.ifmath.compiler.infrastructure.compiler.iface.ISyntacticAnalyzer;
-import br.ifmath.compiler.infrastructure.props.RegexPattern;
 import br.ifmath.compiler.infrastructure.stack.Stack;
 import br.ifmath.compiler.infrastructure.stack.exception.StackAddNullItemException;
+import br.ifmath.compiler.infrastructure.util.MathOperatorUtil;
 import br.ifmath.compiler.infrastructure.util.StringUtil;
 
 import java.util.ArrayList;
@@ -72,15 +71,13 @@ public class Compiler implements ICompiler {
     }
 
     @Override
-    public IAnswer analyse(IExpertSystem expertSystem, AnswerType answerType, String... expressions) throws UnrecognizedLexemeException, UnrecognizedStructureException, InvalidAlgebraicExpressionException, InvalidDistributiveOperationException {
+    public IAnswer analyse(IExpertSystem expertSystem, AnswerType answerType, String... expressions) throws UnrecognizedLexemeException, UnrecognizedStructureException, InvalidAlgebraicExpressionException {
         this.expertSystem = expertSystem;
         this.answerType = answerType;
         this.intermediateCodes = new ArrayList<>();
 
         for (String expression : expressions) {
-            if (StringUtil.contains(expression, RegexPattern.INVALID_DISTRIBUTIVE_OPERATION.toString()))
-                throw new InvalidDistributiveOperationException();
-
+            expression = MathOperatorUtil.replaceReducedDistributive(expression);
             setUp();
             frontEnd(expression);
             this.intermediateCodes.add(intermediateCodeGenerator.generateCode(e.getParameter1(), e.getComparison(), e.getParameter2()));

--- a/src/main/java/br/ifmath/compiler/application/ICompiler.java
+++ b/src/main/java/br/ifmath/compiler/application/ICompiler.java
@@ -4,7 +4,6 @@ import br.ifmath.compiler.domain.expertsystem.AnswerType;
 import br.ifmath.compiler.domain.expertsystem.IAnswer;
 import br.ifmath.compiler.domain.expertsystem.IExpertSystem;
 import br.ifmath.compiler.domain.expertsystem.InvalidAlgebraicExpressionException;
-import br.ifmath.compiler.domain.grammar.InvalidDistributiveOperationException;
 import br.ifmath.compiler.domain.grammar.nonterminal.UnrecognizedStructureException;
 import br.ifmath.compiler.infrastructure.compiler.UnrecognizedLexemeException;
 
@@ -14,7 +13,7 @@ import br.ifmath.compiler.infrastructure.compiler.UnrecognizedLexemeException;
  */
 public interface ICompiler {
 
-    public IAnswer analyse(IExpertSystem expertSystem, AnswerType answerType, String... expressions) throws UnrecognizedLexemeException, UnrecognizedStructureException, InvalidAlgebraicExpressionException, InvalidDistributiveOperationException;
+    public IAnswer analyse(IExpertSystem expertSystem, AnswerType answerType, String... expressions) throws UnrecognizedLexemeException, UnrecognizedStructureException, InvalidAlgebraicExpressionException;
 
     public void frontEnd(String expression) throws UnrecognizedLexemeException, UnrecognizedStructureException;
 

--- a/src/main/java/br/ifmath/compiler/domain/expertsystem/InvalidAlgebraicExpressionException.java
+++ b/src/main/java/br/ifmath/compiler/domain/expertsystem/InvalidAlgebraicExpressionException.java
@@ -12,11 +12,11 @@ package br.ifmath.compiler.domain.expertsystem;
 public class InvalidAlgebraicExpressionException extends Exception {
 
     /**
-	 * 
-	 */
-	private static final long serialVersionUID = 1396171472572015846L;
+    * 
+    */
+    private static final long serialVersionUID = 1396171472572015846L;
 
-	public InvalidAlgebraicExpressionException(String message) {
+    public InvalidAlgebraicExpressionException(String message) {
         super(message);
     }
     

--- a/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationExpertSystem.java
+++ b/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationExpertSystem.java
@@ -14,6 +14,7 @@ import br.ifmath.compiler.domain.expertsystem.InvalidAlgebraicExpressionExceptio
 import br.ifmath.compiler.domain.expertsystem.Step;
 import br.ifmath.compiler.infrastructure.props.RegexPattern;
 import br.ifmath.compiler.infrastructure.util.StringUtil;
+import com.sun.tools.doclint.Entity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -138,6 +139,10 @@ public class LinearEquationExpertSystem implements IExpertSystem {
         double coeficient = 0d;
         String variable;
         
+        if (StringUtil.isEmpty(sources.get(0).getComparison())) {
+            throw new InvalidAlgebraicExpressionException("Equação deve possuir uma igualdade.");
+        }
+        
         if (isVariable(sources.get(0).getLeft())) {
             variable = getVariable(sources.get(0).getLeft());
             coeficient += getVariableCoeficient(sources.get(0).getLeft());
@@ -165,6 +170,13 @@ public class LinearEquationExpertSystem implements IExpertSystem {
                 coeficient += getVariableCoeficient(expandedQuadruple.getArgument2());
                 if (StringUtil.isNotEmpty(variable) && !variables.contains(variable))
                     variables.add(variable);
+            }
+            
+            if (!expandedQuadruple.isPlus()
+                    && !expandedQuadruple.isFraction()
+                    && !expandedQuadruple.isTimes()
+                    && !expandedQuadruple.isMinusOrNegative()) {
+                throw new InvalidAlgebraicExpressionException("A expressão deve possuir apenas as seguintes operações: +, -, * e /.");
             }
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationRuleDistributive.java
+++ b/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationRuleDistributive.java
@@ -270,6 +270,25 @@ public class LinearEquationRuleDistributive implements IRule {
     private String calculateDistributive(ThreeAddressCode source, String multiplier, String innerOperationString, int position, int level, ExpandedQuadruple parent, boolean lastOperationIsNegative, boolean changeSignal, String currentResult) {
         ExpandedQuadruple operation = source.findQuadrupleByResult(innerOperationString);
         
+        if (operation == null) {
+            String value = (lastOperationIsNegative ? "-" : "") + innerOperationString;
+            double result = MathOperatorUtil.times(multiplier, value);
+            
+            if (changeSignal) {
+                result *= (-1);
+            }
+            
+            String valueToReturn = generateParameter(result) + getVariable(multiplier, value);
+            if (result < 0) { 
+                if (parent == null || parent.getArgument1().equals(currentResult))
+                    return createNegativeNumberQuadruple(valueToReturn, position, level);
+                else
+                    parent.setOperator("-");
+            }
+            
+            return valueToReturn;
+        }
+        
         expandedQuadruples.removeAll(source.findAllQuadruplesByResultOrArgument(innerOperationString));
         
         if (!operation.isPlusOrMinus()) {

--- a/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationRuleIsolateTerms.java
+++ b/src/main/java/br/ifmath/compiler/domain/expertsystem/linearequation/LinearEquationRuleIsolateTerms.java
@@ -155,7 +155,7 @@ public class LinearEquationRuleIsolateTerms implements IRule {
     
     private void isolateVariable(String param, ExpandedQuadruple parent, ExpandedQuadruple grandparent, boolean left, boolean lastOperationIsMinus) {
         if (parent == null || (parent.getArgument1().equals(param) && grandparent == null)) {
-            quadrupleVariable = addTermToQuadruple(quadrupleVariable, param, !left, 0, false);
+            quadrupleVariable = addTermToQuadruple(quadrupleVariable, param, !left && !lastOperationIsMinus, 0, false);
         } else if (parent.getArgument1().equals(param) && grandparent != null && grandparent.getArgument2().equals(parent.getResult())) {
             quadrupleVariable = addTermToQuadruple(quadrupleVariable, param, !(grandparent.isMinusOrNegative() ^ left), 0, false);
         } else if (parent.getArgument1().equals(param) && !parent.isNegative()){

--- a/src/main/java/br/ifmath/compiler/domain/grammar/InvalidDistributiveOperationException.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/InvalidDistributiveOperationException.java
@@ -1,9 +1,0 @@
-package br.ifmath.compiler.domain.grammar;
-
-public class InvalidDistributiveOperationException extends Exception {
-
-    public InvalidDistributiveOperationException() {
-        super("Operação distributiva inválida. O operador de multiplicação (*) sempre deve ser utilizado!");
-    }
-
-}

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/C.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/C.java
@@ -2,7 +2,7 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction4;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction5;
 import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
 
 /**
@@ -31,7 +31,7 @@ public class C extends NonTerminal {
             Equal equal = new Equal();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, equal),
+                    new SemanticAction5(this, equal),
                     equal
             };
         }
@@ -40,7 +40,7 @@ public class C extends NonTerminal {
             Different different = new Different();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, different),
+                    new SemanticAction5(this, different),
                     different
             };
         }
@@ -49,7 +49,7 @@ public class C extends NonTerminal {
             Lower lower = new Lower();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, lower),
+                    new SemanticAction5(this, lower),
                     lower
             };
         }
@@ -58,7 +58,7 @@ public class C extends NonTerminal {
             LowerOrEqual lowerOrEqual = new LowerOrEqual();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, lowerOrEqual),
+                    new SemanticAction5(this, lowerOrEqual),
                     lowerOrEqual
             };
         }
@@ -67,7 +67,7 @@ public class C extends NonTerminal {
             Greater greater = new Greater();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, greater),
+                    new SemanticAction5(this, greater),
                     greater
             };
         }
@@ -76,7 +76,7 @@ public class C extends NonTerminal {
             GreaterOrEqual greaterOrEqual = new GreaterOrEqual();
 
             return new GrammarSymbol[] {
-                    new SemanticAction4(this, greaterOrEqual),
+                    new SemanticAction5(this, greaterOrEqual),
                     greaterOrEqual
             };
         }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/E.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/E.java
@@ -9,8 +9,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction1;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction2;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction3;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction4;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -85,9 +85,9 @@ public class E extends NonTerminal {
             C c = new C();
             
             return new GrammarSymbol[] {
-                new SemanticAction3(this, t1, t2, c),
+                new SemanticAction4(this, t1, t2, c),
                 t2,
-                new SemanticAction2(t2),
+                new SemanticAction3(t2),
                 c,
                 t1,
                 new SemanticAction1(t1)

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/E.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/E.java
@@ -9,8 +9,7 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction1;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction3;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction4;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction2;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -80,17 +79,14 @@ public class E extends NonTerminal {
                 Minus.class
             )
         ) {
-            T t1 = new T();
-            T t2 = new T();
-            C c = new C();
+            T t = new T();
+            EL el = new EL();
             
             return new GrammarSymbol[] {
-                new SemanticAction4(this, t1, t2, c),
-                t2,
-                new SemanticAction3(t2),
-                c,
-                t1,
-                new SemanticAction1(t1)
+                new SemanticAction2(this, t, el),
+                el,
+                t,
+                new SemanticAction1(t)
             };
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
@@ -11,6 +11,12 @@ import br.ifmath.compiler.domain.grammar.GrammarSymbol;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction3;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction4;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.Different;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.Equal;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.Greater;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.GreaterOrEqual;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.Lower;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.LowerOrEqual;
 
 /**
  *
@@ -44,7 +50,12 @@ public class EL extends NonTerminal {
     @Override
     public GrammarSymbol[] derivate(Token token) throws UnrecognizedStructureException {
         if (token.isInstanceOfAny(
-        sds
+            Equal.class,
+            Different.class,
+            Greater.class,
+            GreaterOrEqual.class,
+            Lower.class,
+            LowerOrEqual.class
         )) {
             C c = new C();
             T t = new T();
@@ -57,10 +68,7 @@ public class EL extends NonTerminal {
             };
         }
         
-        if (token.isInstanceOfAny(
-                Success.class
-            )
-        ) {
+        if (token.isInstanceOfAny(Success.class)) {
             return new GrammarSymbol[] { };
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
@@ -1,0 +1,128 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package br.ifmath.compiler.domain.grammar.nonterminal;
+
+
+import br.ifmath.compiler.domain.compiler.Token;
+import br.ifmath.compiler.domain.grammar.GrammarSymbol;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction7;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction8;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction9;
+import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
+import br.ifmath.compiler.domain.grammar.terminal.Success;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
+import br.ifmath.compiler.domain.grammar.terminal.operator.Minus;
+import br.ifmath.compiler.domain.grammar.terminal.operator.Plus;
+import br.ifmath.compiler.domain.grammar.terminal.precedence.EndBracket;
+import br.ifmath.compiler.domain.grammar.terminal.precedence.EndKey;
+import br.ifmath.compiler.domain.grammar.terminal.precedence.EndParentheses;
+
+/**
+ *
+ * @author alex_
+ */
+public class EL extends NonTerminal {
+
+    private String address;
+    private int position;
+    private int level;
+    private boolean value;
+    private String operator;
+    
+    public EL() {
+        super("TL");
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public void setLevel(int level) {
+        this.level = level;
+    }
+
+    public boolean isValue() {
+        return value;
+    }
+
+    public void setValue(boolean value) {
+        this.value = value;
+    }
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @Override
+    public GrammarSymbol[] derivate(Token token) throws UnrecognizedStructureException {
+        if (token.isInstanceOfAny(Plus.class)) {
+            M m = new M();
+            EL tl1 = new EL();
+            
+            return new GrammarSymbol[] {
+                new SemanticAction8(m, this, tl1),
+                tl1,
+                m,
+                new SemanticAction7(m, this, tl1),
+                new Plus()
+            };
+        }
+        
+        if (token.isInstanceOfAny(Minus.class)) {
+            M m = new M();
+            EL tl1 = new EL();
+            
+            return new GrammarSymbol[] {
+                new SemanticAction9(m, this, tl1),
+                tl1,
+                m,
+                new SemanticAction7(m, this, tl1),
+                new Minus()
+            };
+        }
+        
+        if (token.isInstanceOfAny(
+                EndParentheses.class,
+                EndBracket.class,
+                EndKey.class,
+                Equal.class,
+                Different.class,
+                Greater.class,
+                GreaterOrEqual.class,
+                Lower.class,
+                LowerOrEqual.class,
+                Semicolon.class,
+                Success.class
+            )
+        ) {
+            return new GrammarSymbol[] { new SemanticAction10(this) };
+        }
+        
+        throw new UnrecognizedStructureException(this, token);
+    }
+    
+}

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
@@ -8,18 +8,9 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction11;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction8;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction9;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
-import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction3;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction4;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
-import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
-import br.ifmath.compiler.domain.grammar.terminal.operator.Minus;
-import br.ifmath.compiler.domain.grammar.terminal.operator.Plus;
-import br.ifmath.compiler.domain.grammar.terminal.precedence.EndBracket;
-import br.ifmath.compiler.domain.grammar.terminal.precedence.EndKey;
-import br.ifmath.compiler.domain.grammar.terminal.precedence.EndParentheses;
 
 /**
  *
@@ -27,99 +18,50 @@ import br.ifmath.compiler.domain.grammar.terminal.precedence.EndParentheses;
  */
 public class EL extends NonTerminal {
 
-    private String address;
-    private int position;
-    private int level;
-    private boolean value;
-    private String operator;
+    private String parameter;
+    private String comparison;
     
     public EL() {
-        super("TL");
+        super("EL");
     }
 
-    public String getAddress() {
-        return address;
+    public String getParameter() {
+        return parameter;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
+    public void setParameter(String parameter) {
+        this.parameter = parameter;
     }
 
-    public int getPosition() {
-        return position;
+    public String getComparison() {
+        return comparison;
     }
 
-    public void setPosition(int position) {
-        this.position = position;
+    public void setComparison(String comparison) {
+        this.comparison = comparison;
     }
-
-    public int getLevel() {
-        return level;
-    }
-
-    public void setLevel(int level) {
-        this.level = level;
-    }
-
-    public boolean isValue() {
-        return value;
-    }
-
-    public void setValue(boolean value) {
-        this.value = value;
-    }
-
-    public String getOperator() {
-        return operator;
-    }
-
-    public void setOperator(String operator) {
-        this.operator = operator;
-    }
-
+    
     @Override
     public GrammarSymbol[] derivate(Token token) throws UnrecognizedStructureException {
-        if (token.isInstanceOfAny(Plus.class)) {
-            M m = new M();
-            EL tl1 = new EL();
+        if (token.isInstanceOfAny(
+        sds
+        )) {
+            C c = new C();
+            T t = new T();
             
             return new GrammarSymbol[] {
-                new SemanticAction9(m, this, tl1),
-                tl1,
-                m,
-                new SemanticAction8(m, this, tl1),
-                new Plus()
-            };
-        }
-        
-        if (token.isInstanceOfAny(Minus.class)) {
-            M m = new M();
-            EL tl1 = new EL();
-            
-            return new GrammarSymbol[] {
-                new SemanticAction10(m, this, tl1),
-                tl1,
-                m,
-                new SemanticAction8(m, this, tl1),
-                new Minus()
+                new SemanticAction4(this, t, c),
+                t,
+                c,
+                new SemanticAction3(t),
             };
         }
         
         if (token.isInstanceOfAny(
-                EndParentheses.class,
-                EndBracket.class,
-                EndKey.class,
-                Equal.class,
-                Different.class,
-                Greater.class,
-                GreaterOrEqual.class,
-                Lower.class,
-                LowerOrEqual.class,
-                Semicolon.class,
                 Success.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction11(this) };
+            return new GrammarSymbol[] { };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/EL.java
@@ -8,10 +8,10 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction7;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction11;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction8;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction9;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
 import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
 import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
@@ -84,10 +84,10 @@ public class EL extends NonTerminal {
             EL tl1 = new EL();
             
             return new GrammarSymbol[] {
-                new SemanticAction8(m, this, tl1),
+                new SemanticAction9(m, this, tl1),
                 tl1,
                 m,
-                new SemanticAction7(m, this, tl1),
+                new SemanticAction8(m, this, tl1),
                 new Plus()
             };
         }
@@ -97,10 +97,10 @@ public class EL extends NonTerminal {
             EL tl1 = new EL();
             
             return new GrammarSymbol[] {
-                new SemanticAction9(m, this, tl1),
+                new SemanticAction10(m, this, tl1),
                 tl1,
                 m,
-                new SemanticAction7(m, this, tl1),
+                new SemanticAction8(m, this, tl1),
                 new Minus()
             };
         }
@@ -119,7 +119,7 @@ public class EL extends NonTerminal {
                 Success.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction10(this) };
+            return new GrammarSymbol[] { new SemanticAction11(this) };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/F.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/F.java
@@ -60,10 +60,10 @@ public class F extends NonTerminal {
             T t = new T();
             
             return new GrammarSymbol[] {
-                new SemanticAction29(t, this),
+                new SemanticAction30(t, this),
                 new EndParentheses(),
                 t,
-                new SemanticAction28(t, this),
+                new SemanticAction29(t, this),
                 new BeginParentheses()
             };
         }
@@ -72,10 +72,10 @@ public class F extends NonTerminal {
             T t = new T();
             
             return new GrammarSymbol[] {
-                new SemanticAction29(t, this),
+                new SemanticAction30(t, this),
                 new EndBracket(),
                 t,
-                new SemanticAction28(t, this),
+                new SemanticAction29(t, this),
                 new BeginBracket()
             };
         }
@@ -84,10 +84,10 @@ public class F extends NonTerminal {
             T t = new T();
             
             return new GrammarSymbol[] {
-                new SemanticAction29(t, this),
+                new SemanticAction30(t, this),
                 new EndKey(),
                 t,
-                new SemanticAction28(t, this),
+                new SemanticAction29(t, this),
                 new BeginKey()
             };
         }
@@ -95,7 +95,7 @@ public class F extends NonTerminal {
         if (token.isInstanceOfAny(Id.class)) {
             Id id = new Id();
             return new GrammarSymbol[] {
-                new SemanticAction30(this, id),
+                new SemanticAction31(this, id),
                 id
             };
         }
@@ -103,7 +103,7 @@ public class F extends NonTerminal {
         if (token.isInstanceOfAny(IdWithCoefficient.class)) {
             IdWithCoefficient idWithCoefficient = new IdWithCoefficient();
             return new GrammarSymbol[] {
-                new SemanticAction30(this, idWithCoefficient),
+                new SemanticAction31(this, idWithCoefficient),
                 idWithCoefficient
             };
         }
@@ -112,7 +112,7 @@ public class F extends NonTerminal {
             NaturalNumber integerNumber = new NaturalNumber();
             
             return new GrammarSymbol[] {
-                new SemanticAction30(this, integerNumber),
+                new SemanticAction31(this, integerNumber),
                 integerNumber
             };
         }
@@ -120,7 +120,7 @@ public class F extends NonTerminal {
         if (token.isInstanceOfAny(DecimalNumber.class)) {
             DecimalNumber decimalNumber = new DecimalNumber();
             return new GrammarSymbol[] {
-                new SemanticAction30(this, decimalNumber),
+                new SemanticAction31(this, decimalNumber),
                 decimalNumber
             };
         }
@@ -138,9 +138,9 @@ public class F extends NonTerminal {
             Func func = new Func();
             
             return new GrammarSymbol[] {
-                new SemanticAction27(func, this),
+                new SemanticAction28(func, this),
                 func,
-                new SemanticAction26(func, this)
+                new SemanticAction27(func, this)
             };
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/Func.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/Func.java
@@ -78,11 +78,11 @@ public class Func extends NonTerminal {
             Cosine cosine = new Cosine();
             
             return new GrammarSymbol[] {
-                new SemanticAction32(this, t),
+                new SemanticAction33(this, t),
                 new EndParentheses(),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, cosine),
+                new SemanticAction32(this, cosine),
                 cosine
             };
         }
@@ -92,11 +92,11 @@ public class Func extends NonTerminal {
             Sine sine = new Sine();
             
             return new GrammarSymbol[] {
-                new SemanticAction32(this, t),
+                new SemanticAction33(this, t),
                 new EndParentheses(),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, sine),
+                new SemanticAction32(this, sine),
                 sine
             };
         }
@@ -105,11 +105,11 @@ public class Func extends NonTerminal {
             Tangent tangent = new Tangent();
             
             return new GrammarSymbol[] {
-                new SemanticAction32(this, t),
+                new SemanticAction33(this, t),
                 new EndParentheses(),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, tangent),
+                new SemanticAction32(this, tangent),
                 tangent
             };
         }
@@ -118,12 +118,12 @@ public class Func extends NonTerminal {
             SquareRoot squareRoot = new SquareRoot();
             
             return new GrammarSymbol[] {
-                new SemanticAction34(this, t),
+                new SemanticAction35(this, t),
                 new EndParentheses(),
-                new SemanticAction33(this),
+                new SemanticAction34(this),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, squareRoot),
+                new SemanticAction32(this, squareRoot),
                 squareRoot
             };
         }
@@ -134,14 +134,14 @@ public class Func extends NonTerminal {
             NaturalNumber integerNumber = new NaturalNumber();
             
             return new GrammarSymbol[] {
-                new SemanticAction34(this, t),
+                new SemanticAction35(this, t),
                 new EndParentheses(),
-                new SemanticAction35(this, integerNumber),
+                new SemanticAction36(this, integerNumber),
                 integerNumber,
                 new Semicolon(),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, root),
+                new SemanticAction32(this, root),
                 root
             };
         }
@@ -151,12 +151,12 @@ public class Func extends NonTerminal {
             Log10 log10 = new Log10();
                     
             return new GrammarSymbol[] {
-                new SemanticAction34(this, t),
+                new SemanticAction35(this, t),
                 new EndParentheses(),
-                new SemanticAction36(this),
+                new SemanticAction37(this),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, log10),
+                new SemanticAction32(this, log10),
                 log10
             };
         }
@@ -167,14 +167,14 @@ public class Func extends NonTerminal {
             NaturalNumber integerNumber = new NaturalNumber();
             
             return new GrammarSymbol[] {
-                new SemanticAction34(this, t),
+                new SemanticAction35(this, t),
                 new EndParentheses(),
-                new SemanticAction35(this, integerNumber),
+                new SemanticAction36(this, integerNumber),
                 integerNumber,
                 new Semicolon(),
                 t,
                 new BeginParentheses(),
-                new SemanticAction31(this, log),
+                new SemanticAction32(this, log),
                 log
             };
         }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/M.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/M.java
@@ -7,8 +7,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction11;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction12;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction13;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -82,10 +82,10 @@ public class M extends NonTerminal {
             ML ml = new ML();
             
             return new GrammarSymbol[] {
-                new SemanticAction12(p, this, ml),
+                new SemanticAction13(p, this, ml),
                 ml,
                 p,
-                new SemanticAction11(p, this, ml)
+                new SemanticAction12(p, this, ml)
             };
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/ML.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/ML.java
@@ -7,10 +7,10 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction13;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction14;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction15;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction16;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction17;
 import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
 import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
@@ -85,10 +85,10 @@ public class ML extends NonTerminal {
             ML pl1 = new ML();
             
             return new GrammarSymbol[] {
-                new SemanticAction14(p, this, pl1),
+                new SemanticAction15(p, this, pl1),
                 pl1,
                 p,
-                new SemanticAction13(p, this, pl1),
+                new SemanticAction14(p, this, pl1),
                 new Times()
             };
         }
@@ -98,10 +98,10 @@ public class ML extends NonTerminal {
             ML ml1 = new ML();
             
             return new GrammarSymbol[] {
-                new SemanticAction15(p, this, ml1),
+                new SemanticAction16(p, this, ml1),
                 ml1,
                 p,
-                new SemanticAction13(p, this, ml1),
+                new SemanticAction14(p, this, ml1),
                 new Fraction()
             };
         }
@@ -122,7 +122,7 @@ public class ML extends NonTerminal {
                 Success.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction16(this) };
+            return new GrammarSymbol[] { new SemanticAction17(this) };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/O.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/O.java
@@ -7,8 +7,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction22;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction23;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction24;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -82,9 +82,9 @@ public class O extends NonTerminal {
             F f = new F();
             
             return new GrammarSymbol[] {
-                new SemanticAction23(s, f, this),
+                new SemanticAction24(s, f, this),
                 f,
-                new SemanticAction22(f, this),
+                new SemanticAction23(f, this),
                 s
             };
         }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/P.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/P.java
@@ -7,8 +7,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction17;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction18;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction19;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -82,10 +82,10 @@ public class P extends NonTerminal {
             PL ml = new PL();
 
             return new GrammarSymbol[] {
-                new SemanticAction18(p, this, ml),
+                new SemanticAction19(p, this, ml),
                 ml,
                 p,
-                new SemanticAction17(p, this, ml)
+                new SemanticAction18(p, this, ml)
             };
         }
 

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/PL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/PL.java
@@ -8,9 +8,9 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction19;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction20;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction21;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction22;
 import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
 import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
@@ -82,10 +82,10 @@ public class PL extends NonTerminal {
             PL pl1 = new PL();
             
             return new GrammarSymbol[] {
-                new SemanticAction20(o, this, pl1),
+                new SemanticAction21(o, this, pl1),
                 pl1,
                 o,
-                new SemanticAction19(o, this, pl1),
+                new SemanticAction20(o, this, pl1),
                 new Pow()
             };
         }
@@ -108,7 +108,7 @@ public class PL extends NonTerminal {
                 Success.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction21(this) };
+            return new GrammarSymbol[] { new SemanticAction22(this) };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/S.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/S.java
@@ -7,8 +7,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction24;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction25;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction26;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -44,14 +44,14 @@ public class S extends NonTerminal {
     public GrammarSymbol[] derivate(Token token) throws UnrecognizedStructureException {
         if (token.isInstanceOfAny(Plus.class)) {
             return new GrammarSymbol[] {
-                new SemanticAction24(this),
+                new SemanticAction25(this),
                 new Plus()
             };
         }
         
         if (token.isInstanceOfAny(Minus.class)) {
             return new GrammarSymbol[] {
-                new SemanticAction25(this),
+                new SemanticAction26(this),
                 new Minus()
             };
         }
@@ -72,7 +72,7 @@ public class S extends NonTerminal {
                 DecimalNumber.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction24(this) };
+            return new GrammarSymbol[] { new SemanticAction25(this) };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/T.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/T.java
@@ -8,8 +8,8 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction5;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction6;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction7;
 import br.ifmath.compiler.domain.grammar.terminal.function.*;
 import br.ifmath.compiler.domain.grammar.terminal.id.Id;
 import br.ifmath.compiler.domain.grammar.terminal.id.IdWithCoefficient;
@@ -83,10 +83,10 @@ public class T extends NonTerminal {
             TL tl = new TL();
             
             return new GrammarSymbol[] {
-                new SemanticAction6(m, tl, this),
+                new SemanticAction7(m, tl, this),
                 tl,
                 m,
-                new SemanticAction5(m, tl, this)
+                new SemanticAction6(m, tl, this)
             };
         }
         

--- a/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/TL.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/nonterminal/TL.java
@@ -8,10 +8,10 @@ package br.ifmath.compiler.domain.grammar.nonterminal;
 
 import br.ifmath.compiler.domain.compiler.Token;
 import br.ifmath.compiler.domain.grammar.GrammarSymbol;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
-import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction7;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction11;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction8;
 import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction9;
+import br.ifmath.compiler.domain.grammar.semanticaction.SemanticAction10;
 import br.ifmath.compiler.domain.grammar.terminal.Semicolon;
 import br.ifmath.compiler.domain.grammar.terminal.Success;
 import br.ifmath.compiler.domain.grammar.terminal.comparison.*;
@@ -84,10 +84,10 @@ public class TL extends NonTerminal {
             TL tl1 = new TL();
             
             return new GrammarSymbol[] {
-                new SemanticAction8(m, this, tl1),
+                new SemanticAction9(m, this, tl1),
                 tl1,
                 m,
-                new SemanticAction7(m, this, tl1),
+                new SemanticAction8(m, this, tl1),
                 new Plus()
             };
         }
@@ -97,10 +97,10 @@ public class TL extends NonTerminal {
             TL tl1 = new TL();
             
             return new GrammarSymbol[] {
-                new SemanticAction9(m, this, tl1),
+                new SemanticAction10(m, this, tl1),
                 tl1,
                 m,
-                new SemanticAction7(m, this, tl1),
+                new SemanticAction8(m, this, tl1),
                 new Minus()
             };
         }
@@ -119,7 +119,7 @@ public class TL extends NonTerminal {
                 Success.class
             )
         ) {
-            return new GrammarSymbol[] { new SemanticAction10(this) };
+            return new GrammarSymbol[] { new SemanticAction11(this) };
         }
         
         throw new UnrecognizedStructureException(this, token);

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction10.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction10.java
@@ -5,6 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+import br.ifmath.compiler.domain.grammar.nonterminal.M;
 import br.ifmath.compiler.domain.grammar.nonterminal.TL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -14,17 +15,29 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction10 extends SemanticAction {
 
+    private final M m;
     private final TL tl;
+    private final TL tl1;
     
-    public SemanticAction10(TL tl) {
+    public SemanticAction10(M m, TL tl, TL tl1) {
         super("AS10");
         
+        this.m = m;
         this.tl = tl;
+        this.tl1 = tl1;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        tl.setValue(false);
+       tl.setValue(true);
+        tl.setOperator("-");
+        
+        if (tl1.isValue()) {
+            tl.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(tl1.getOperator(), m.getAddress(), tl1.getAddress(), tl.getAddress(), tl.getPosition(), tl.getLevel());
+        } else {
+            tl.setAddress(m.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction11.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction11.java
@@ -5,9 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.M;
-import br.ifmath.compiler.domain.grammar.nonterminal.ML;
-import br.ifmath.compiler.domain.grammar.nonterminal.P;
+import br.ifmath.compiler.domain.grammar.nonterminal.TL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,24 +14,17 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction11 extends SemanticAction {
 
-    private final P p;
-    private final M m;
-    private final ML ml;
-            
-    public SemanticAction11(P p, M m, ML ml) {
+    private final TL tl;
+    
+    public SemanticAction11(TL tl) {
         super("AS11");
         
-        this.p = p;
-        this.m = m;
-        this.ml = ml;
+        this.tl = tl;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        p.setPosition(m.getPosition());
-        ml.setPosition(m.getPosition());
-        p.setLevel(m.getLevel());
-        ml.setLevel(m.getLevel());
+        tl.setValue(false);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction12.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction12.java
@@ -5,7 +5,6 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.M;
 import br.ifmath.compiler.domain.grammar.nonterminal.ML;
 import br.ifmath.compiler.domain.grammar.nonterminal.P;
@@ -20,7 +19,7 @@ public class SemanticAction12 extends SemanticAction {
     private final P p;
     private final M m;
     private final ML ml;
-    
+            
     public SemanticAction12(P p, M m, ML ml) {
         super("AS12");
         
@@ -31,12 +30,10 @@ public class SemanticAction12 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        if (ml.isValue()) {
-            m.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(ml.getOperator(), p.getAddress(), ml.getAddress(), m.getAddress(), m.getPosition(), m.getLevel());
-        } else {
-            m.setAddress(p.getAddress());
-        }
+        p.setPosition(m.getPosition());
+        ml.setPosition(m.getPosition());
+        p.setLevel(m.getLevel());
+        ml.setLevel(m.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction13.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction13.java
@@ -6,6 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 
+import br.ifmath.compiler.domain.grammar.nonterminal.M;
 import br.ifmath.compiler.domain.grammar.nonterminal.ML;
 import br.ifmath.compiler.domain.grammar.nonterminal.P;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
@@ -17,23 +18,25 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction13 extends SemanticAction {
 
     private final P p;
+    private final M m;
     private final ML ml;
-    private final ML ml1;
     
-    public SemanticAction13(P p, ML ml, ML ml1) {
+    public SemanticAction13(P p, M m, ML ml) {
         super("AS13");
         
         this.p = p;
+        this.m = m;
         this.ml = ml;
-        this.ml1 = ml1;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        p.setPosition(ml.getPosition());
-        ml1.setPosition(ml.getPosition());
-        p.setLevel(ml.getLevel());
-        ml1.setLevel(ml.getLevel());
+        if (ml.isValue()) {
+            m.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(ml.getOperator(), p.getAddress(), ml.getAddress(), m.getAddress(), m.getPosition(), m.getLevel());
+        } else {
+            m.setAddress(p.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction14.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction14.java
@@ -5,6 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+
 import br.ifmath.compiler.domain.grammar.nonterminal.ML;
 import br.ifmath.compiler.domain.grammar.nonterminal.P;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
@@ -29,15 +30,10 @@ public class SemanticAction14 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        ml.setValue(true);
-        ml.setOperator("*");
-        
-        if (ml1.isValue()) {
-            ml.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(ml1.getOperator(), p.getAddress(), ml1.getAddress(), ml.getAddress(), ml.getPosition(), ml.getLevel());
-        } else {
-            ml.setAddress(p.getAddress());
-        }
+        p.setPosition(ml.getPosition());
+        ml1.setPosition(ml.getPosition());
+        p.setLevel(ml.getLevel());
+        ml1.setLevel(ml.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction15.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction15.java
@@ -30,7 +30,7 @@ public class SemanticAction15 extends SemanticAction {
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
         ml.setValue(true);
-        ml.setOperator("/");
+        ml.setOperator("*");
         
         if (ml1.isValue()) {
             ml.setAddress(intermediateCodeGenerator.getNextTemporary().toString());

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction16.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction16.java
@@ -6,6 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.ML;
+import br.ifmath.compiler.domain.grammar.nonterminal.P;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -14,17 +15,29 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction16 extends SemanticAction {
 
+    private final P p;
     private final ML ml;
+    private final ML ml1;
     
-    public SemanticAction16(ML ml) {
+    public SemanticAction16(P p, ML ml, ML ml1) {
         super("AS16");
         
+        this.p = p;
         this.ml = ml;
+        this.ml1 = ml1;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        ml.setValue(false);
+        ml.setValue(true);
+        ml.setOperator("/");
+        
+        if (ml1.isValue()) {
+            ml.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(ml1.getOperator(), p.getAddress(), ml1.getAddress(), ml.getAddress(), ml.getPosition(), ml.getLevel());
+        } else {
+            ml.setAddress(p.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction17.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction17.java
@@ -5,9 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.O;
-import br.ifmath.compiler.domain.grammar.nonterminal.P;
-import br.ifmath.compiler.domain.grammar.nonterminal.PL;
+import br.ifmath.compiler.domain.grammar.nonterminal.ML;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,24 +14,17 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction17 extends SemanticAction {
 
-    private final O o;
-    private final P p;
-    private final PL pl;
+    private final ML ml;
     
-    public SemanticAction17(O o, P p, PL pl) {
+    public SemanticAction17(ML ml) {
         super("AS17");
         
-        this.o = o;
-        this.p = p;
-        this.pl = pl;
+        this.ml = ml;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        o.setPosition(p.getPosition());
-        pl.setPosition(p.getPosition());
-        o.setLevel(p.getLevel());
-        pl.setLevel(p.getLevel());
+        ml.setValue(false);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction18.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction18.java
@@ -5,7 +5,6 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.O;
 import br.ifmath.compiler.domain.grammar.nonterminal.P;
 import br.ifmath.compiler.domain.grammar.nonterminal.PL;
@@ -31,12 +30,10 @@ public class SemanticAction18 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        if (pl.isValue()) {
-            p.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(pl.getOperator(), o.getAddress(), pl.getAddress(), p.getAddress(), p.getPosition(), p.getLevel());
-        } else {
-            p.setAddress(o.getAddress());
-        }
+        o.setPosition(p.getPosition());
+        pl.setPosition(p.getPosition());
+        o.setLevel(p.getLevel());
+        pl.setLevel(p.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction19.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction19.java
@@ -7,6 +7,7 @@ package br.ifmath.compiler.domain.grammar.semanticaction;
 
 
 import br.ifmath.compiler.domain.grammar.nonterminal.O;
+import br.ifmath.compiler.domain.grammar.nonterminal.P;
 import br.ifmath.compiler.domain.grammar.nonterminal.PL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -17,23 +18,25 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction19 extends SemanticAction {
 
     private final O o;
+    private final P p;
     private final PL pl;
-    private final PL pl1;
     
-    public SemanticAction19(O o, PL pl, PL pl1) {
+    public SemanticAction19(O o, P p, PL pl) {
         super("AS19");
         
         this.o = o;
+        this.p = p;
         this.pl = pl;
-        this.pl1 = pl1;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        o.setPosition(pl.getPosition());
-        pl1.setPosition(pl.getPosition());
-        o.setLevel(pl.getLevel());
-        pl1.setLevel(pl.getLevel());
+        if (pl.isValue()) {
+            p.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(pl.getOperator(), o.getAddress(), pl.getAddress(), p.getAddress(), p.getPosition(), p.getLevel());
+        } else {
+            p.setAddress(o.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction2.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction2.java
@@ -31,8 +31,8 @@ public class SemanticAction2 extends SemanticAction {
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
         e.setParameter1(t.getAddress());
-        e.setComparison(el.getComp());
-        e.setParameter2(el.getParam());
+        e.setComparison(el.getComparison());
+        e.setParameter2(el.getParameter());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction2.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction2.java
@@ -1,0 +1,38 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package br.ifmath.compiler.domain.grammar.semanticaction;
+
+import br.ifmath.compiler.domain.grammar.nonterminal.EL;
+import br.ifmath.compiler.domain.grammar.nonterminal.E;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
+import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
+
+/**
+ *
+ * @author alex_
+ */
+public class SemanticAction2 extends SemanticAction {
+
+    private final E e;
+    private final T t;
+    private final EL el;
+    
+    public SemanticAction2(E e, T t, EL el) {
+        super("AS2");
+        
+        this.e = e;
+        this.t = t;
+        this.el = el;
+    }
+
+    @Override
+    public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
+        e.setParameter1(t.getAddress());
+        e.setComparison(el.getComp());
+        e.setParameter2(el.getParam());
+    }
+    
+}

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction20.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction20.java
@@ -5,6 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+
 import br.ifmath.compiler.domain.grammar.nonterminal.O;
 import br.ifmath.compiler.domain.grammar.nonterminal.PL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
@@ -29,15 +30,10 @@ public class SemanticAction20 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        pl.setValue(true);
-        pl.setOperator("^");
-        
-        if (pl1.isValue()) {
-            pl.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(pl1.getOperator(), o.getAddress(), pl1.getAddress(), pl.getAddress(), pl.getPosition(), pl.getLevel());
-        } else {
-            pl.setAddress(o.getAddress());
-        }
+        o.setPosition(pl.getPosition());
+        pl1.setPosition(pl.getPosition());
+        o.setLevel(pl.getLevel());
+        pl1.setLevel(pl.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction21.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction21.java
@@ -5,6 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+import br.ifmath.compiler.domain.grammar.nonterminal.O;
 import br.ifmath.compiler.domain.grammar.nonterminal.PL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -14,17 +15,29 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction21 extends SemanticAction {
 
-    private PL pl;
+    private final O o;
+    private final PL pl;
+    private final PL pl1;
     
-    public SemanticAction21(PL pl) {
+    public SemanticAction21(O o, PL pl, PL pl1) {
         super("AS21");
         
+        this.o = o;
         this.pl = pl;
+        this.pl1 = pl1;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        pl.setValue(false);
+        pl.setValue(true);
+        pl.setOperator("^");
+        
+        if (pl1.isValue()) {
+            pl.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(pl1.getOperator(), o.getAddress(), pl1.getAddress(), pl.getAddress(), pl.getPosition(), pl.getLevel());
+        } else {
+            pl.setAddress(o.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction22.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction22.java
@@ -5,8 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.F;
-import br.ifmath.compiler.domain.grammar.nonterminal.O;
+import br.ifmath.compiler.domain.grammar.nonterminal.PL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -15,20 +14,17 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction22 extends SemanticAction {
 
-    private final F f;
-    private final O o;
+    private PL pl;
     
-    public SemanticAction22(F f, O o) {
+    public SemanticAction22(PL pl) {
         super("AS22");
         
-        this.f = f;
-        this.o = o;
+        this.pl = pl;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        f.setPosition(o.getPosition());
-        f.setLevel(o.getLevel());
+        pl.setValue(false);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction23.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction23.java
@@ -7,7 +7,6 @@ package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.F;
 import br.ifmath.compiler.domain.grammar.nonterminal.O;
-import br.ifmath.compiler.domain.grammar.nonterminal.S;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,26 +15,20 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction23 extends SemanticAction {
 
-    private final S s;
     private final F f;
     private final O o;
     
-    public SemanticAction23(S s, F f, O o) {
+    public SemanticAction23(F f, O o) {
         super("AS23");
         
-        this.s = s;
         this.f = f;
         this.o = o;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        if (s.isValue()) {
-            o.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation("MINUS", f.getAddress(), o.getAddress(), o.getPosition(), o.getLevel());
-        } else {
-            o.setAddress(f.getAddress());
-        }    
+        f.setPosition(o.getPosition());
+        f.setLevel(o.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction24.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction24.java
@@ -5,6 +5,8 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+import br.ifmath.compiler.domain.grammar.nonterminal.F;
+import br.ifmath.compiler.domain.grammar.nonterminal.O;
 import br.ifmath.compiler.domain.grammar.nonterminal.S;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -15,16 +17,25 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction24 extends SemanticAction {
 
     private final S s;
+    private final F f;
+    private final O o;
     
-    public SemanticAction24(S s) {
+    public SemanticAction24(S s, F f, O o) {
         super("AS24");
         
         this.s = s;
+        this.f = f;
+        this.o = o;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        s.setValue(false);
+        if (s.isValue()) {
+            o.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation("MINUS", f.getAddress(), o.getAddress(), o.getPosition(), o.getLevel());
+        } else {
+            o.setAddress(f.getAddress());
+        }    
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction25.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction25.java
@@ -24,7 +24,7 @@ public class SemanticAction25 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        s.setValue(true);
+        s.setValue(false);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction26.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction26.java
@@ -5,8 +5,7 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.F;
-import br.ifmath.compiler.domain.grammar.nonterminal.Func;
+import br.ifmath.compiler.domain.grammar.nonterminal.S;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -15,20 +14,17 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction26 extends SemanticAction {
 
-    private final Func func;
-    private final F f;
+    private final S s;
     
-    public SemanticAction26(Func func, F f) {
+    public SemanticAction26(S s) {
         super("AS26");
         
-        this.func = func;
-        this.f = f;
+        this.s = s;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setPosition(f.getPosition());
-        func.setLevel(f.getLevel());
+        s.setValue(true);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction27.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction27.java
@@ -5,7 +5,6 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.F;
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
@@ -28,7 +27,8 @@ public class SemanticAction27 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        f.setAddress(func.getAddress());
+        func.setPosition(f.getPosition());
+        func.setLevel(f.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction28.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction28.java
@@ -5,8 +5,9 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+
 import br.ifmath.compiler.domain.grammar.nonterminal.F;
-import br.ifmath.compiler.domain.grammar.nonterminal.T;
+import br.ifmath.compiler.domain.grammar.nonterminal.Func;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -15,20 +16,19 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction28 extends SemanticAction {
 
-    private final T t;
+    private final Func func;
     private final F f;
     
-    public SemanticAction28(T t, F f) {
+    public SemanticAction28(Func func, F f) {
         super("AS28");
         
-        this.t = t;
+        this.func = func;
         this.f = f;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        t.setPosition(f.getPosition());
-        t.setLevel(f.getLevel() + 1);
+        f.setAddress(func.getAddress());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction29.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction29.java
@@ -27,7 +27,8 @@ public class SemanticAction29 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        f.setAddress(t.getAddress());
+        t.setPosition(f.getPosition());
+        t.setLevel(f.getLevel() + 1);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction3.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction3.java
@@ -5,8 +5,6 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.C;
-import br.ifmath.compiler.domain.grammar.nonterminal.E;
 import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -16,25 +14,18 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction3 extends SemanticAction {
 
-    private final E e;
-    private final T t1;
-    private final T t2;
-    private final C c;
+    private final T t; 
     
-    public SemanticAction3(E e, T t1, T t2, C c) {
+    public SemanticAction3(T t) {
         super("AS3");
         
-        this.e = e;
-        this.t1 = t1;
-        this.t2 = t2;
-        this.c = c;
+        this.t = t;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        e.setParameter1(t1.getAddress());
-        e.setComparison(c.getAddress());
-        e.setParameter2(t2.getAddress());
+        t.setPosition(1);
+        t.setLevel(0);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction30.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction30.java
@@ -5,9 +5,8 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.F;
-import br.ifmath.compiler.domain.grammar.terminal.VariableTerminal;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,19 +15,19 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction30 extends SemanticAction {
 
+    private final T t;
     private final F f;
-    private final VariableTerminal variableTerminal;
     
-    public SemanticAction30(F f, VariableTerminal variableTerminal) {
+    public SemanticAction30(T t, F f) {
         super("AS30");
         
+        this.t = t;
         this.f = f;
-        this.variableTerminal = variableTerminal;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        f.setAddress(variableTerminal.getValue());
+        f.setAddress(t.getAddress());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction31.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction31.java
@@ -5,8 +5,9 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.Func;
-import br.ifmath.compiler.domain.grammar.terminal.function.Function;
+
+import br.ifmath.compiler.domain.grammar.nonterminal.F;
+import br.ifmath.compiler.domain.grammar.terminal.VariableTerminal;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -15,19 +16,19 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction31 extends SemanticAction {
 
-    private final Func func;
-    private final Function function;
+    private final F f;
+    private final VariableTerminal variableTerminal;
     
-    public SemanticAction31(Func func, Function function) {
+    public SemanticAction31(F f, VariableTerminal variableTerminal) {
         super("AS31");
         
-        this.func = func;
-        this.function = function;
+        this.f = f;
+        this.variableTerminal = variableTerminal;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setOperator(function.getValue());
+        f.setAddress(variableTerminal.getValue());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction32.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction32.java
@@ -6,7 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
-import br.ifmath.compiler.domain.grammar.nonterminal.T;
+import br.ifmath.compiler.domain.grammar.terminal.function.Function;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,19 +16,18 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction32 extends SemanticAction {
 
     private final Func func;
-    private final T t;
+    private final Function function;
     
-    public SemanticAction32(Func func, T t) {
+    public SemanticAction32(Func func, Function function) {
         super("AS32");
         
         this.func = func;
-        this.t = t;
+        this.function = function;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-        intermediateCodeGenerator.addNewOperation(func.getOperator(), t.getAddress(), func.getAddress(), func.getPosition(), func.getLevel());
+        func.setOperator(function.getValue());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction33.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction33.java
@@ -5,8 +5,8 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,16 +16,19 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction33 extends SemanticAction {
 
     private final Func func;
+    private final T t;
     
-    public SemanticAction33(Func func) {
+    public SemanticAction33(Func func, T t) {
         super("AS33");
         
         this.func = func;
+        this.t = t;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setParameter(2);
+        func.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+        intermediateCodeGenerator.addNewOperation(func.getOperator(), t.getAddress(), func.getAddress(), func.getPosition(), func.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction34.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction34.java
@@ -5,8 +5,8 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
-import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,20 +16,16 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction34 extends SemanticAction {
 
     private final Func func;
-    private final T t;
     
-    public SemanticAction34(Func func, T t) {
+    public SemanticAction34(Func func) {
         super("AS34");
         
         this.func = func;
-        this.t = t;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-        intermediateCodeGenerator.addNewOperation(func.getOperator(), t.getAddress(), Integer.toString(func.getParameter()), 
-                func.getAddress(), func.getPosition(), func.getLevel());
+        func.setParameter(2);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction35.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction35.java
@@ -6,7 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
-import br.ifmath.compiler.domain.grammar.terminal.number.NaturalNumber;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,18 +16,20 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction35 extends SemanticAction {
 
     private final Func func;
-    private final NaturalNumber integerNumber;
+    private final T t;
     
-    public SemanticAction35(Func func, NaturalNumber integerNumber) {
+    public SemanticAction35(Func func, T t) {
         super("AS35");
         
         this.func = func;
-        this.integerNumber = integerNumber;
+        this.t = t;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setParameter(Integer.parseInt(integerNumber.getValue()));
+        func.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+        intermediateCodeGenerator.addNewOperation(func.getOperator(), t.getAddress(), Integer.toString(func.getParameter()), 
+                func.getAddress(), func.getPosition(), func.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction36.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction36.java
@@ -6,6 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.Func;
+import br.ifmath.compiler.domain.grammar.terminal.number.NaturalNumber;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -15,16 +16,18 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
 public class SemanticAction36 extends SemanticAction {
 
     private final Func func;
+    private final NaturalNumber integerNumber;
     
-    public SemanticAction36(Func func) {
+    public SemanticAction36(Func func, NaturalNumber integerNumber) {
         super("AS36");
         
         this.func = func;
+        this.integerNumber = integerNumber;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        func.setParameter(10);
+        func.setParameter(Integer.parseInt(integerNumber.getValue()));
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction37.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction37.java
@@ -5,27 +5,26 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.T;
+import br.ifmath.compiler.domain.grammar.nonterminal.Func;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
  *
  * @author alex_
  */
-public class SemanticAction2 extends SemanticAction {
+public class SemanticAction37 extends SemanticAction {
 
-    private final T t; 
+    private final Func func;
     
-    public SemanticAction2(T t) {
-        super("AS2");
+    public SemanticAction37(Func func) {
+        super("AS37");
         
-        this.t = t;
+        this.func = func;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        t.setPosition(1);
-        t.setLevel(0);
+        func.setParameter(10);
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction4.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction4.java
@@ -5,9 +5,9 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.C;
-import br.ifmath.compiler.domain.grammar.terminal.comparison.Comparison;
+import br.ifmath.compiler.domain.grammar.nonterminal.E;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,19 +16,25 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction4 extends SemanticAction {
 
+    private final E e;
+    private final T t1;
+    private final T t2;
     private final C c;
-    private final Comparison comparison;
     
-    public SemanticAction4(C c, Comparison comparison) {
+    public SemanticAction4(E e, T t1, T t2, C c) {
         super("AS4");
         
+        this.e = e;
+        this.t1 = t1;
+        this.t2 = t2;
         this.c = c;
-        this.comparison = comparison;
     }
-    
+
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        c.setAddress(comparison.getValue());
+        e.setParameter1(t1.getAddress());
+        e.setComparison(c.getAddress());
+        e.setParameter2(t2.getAddress());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction4.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction4.java
@@ -6,7 +6,7 @@
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
 import br.ifmath.compiler.domain.grammar.nonterminal.C;
-import br.ifmath.compiler.domain.grammar.nonterminal.E;
+import br.ifmath.compiler.domain.grammar.nonterminal.EL;
 import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -16,25 +16,22 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction4 extends SemanticAction {
 
-    private final E e;
-    private final T t1;
-    private final T t2;
+    private final EL el;
+    private final T t;
     private final C c;
     
-    public SemanticAction4(E e, T t1, T t2, C c) {
+    public SemanticAction4(EL el, T t, C c) {
         super("AS4");
         
-        this.e = e;
-        this.t1 = t1;
-        this.t2 = t2;
+        this.el = el;
+        this.t = t;
         this.c = c;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        e.setParameter1(t1.getAddress());
-        e.setComparison(c.getAddress());
-        e.setParameter2(t2.getAddress());
+        el.setParameter(t.getAddress());
+        el.setComparison(c.getAddress());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction5.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction5.java
@@ -5,9 +5,9 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-import br.ifmath.compiler.domain.grammar.nonterminal.M;
-import br.ifmath.compiler.domain.grammar.nonterminal.T;
-import br.ifmath.compiler.domain.grammar.nonterminal.TL;
+
+import br.ifmath.compiler.domain.grammar.nonterminal.C;
+import br.ifmath.compiler.domain.grammar.terminal.comparison.Comparison;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
 /**
@@ -16,24 +16,19 @@ import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerat
  */
 public class SemanticAction5 extends SemanticAction {
 
-    private final M m;
-    private final TL tl;
-    private final T t;
+    private final C c;
+    private final Comparison comparison;
     
-    public SemanticAction5(M m, TL tl, T t) {
+    public SemanticAction5(C c, Comparison comparison) {
         super("AS5");
         
-        this.m = m;
-        this.tl = tl;
-        this.t = t;
+        this.c = c;
+        this.comparison = comparison;
     }
-
+    
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        m.setPosition(t.getPosition());
-        tl.setPosition(t.getPosition());
-        m.setLevel(t.getLevel());
-        tl.setLevel(t.getLevel());
+        c.setAddress(comparison.getValue());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction6.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction6.java
@@ -5,7 +5,6 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
-
 import br.ifmath.compiler.domain.grammar.nonterminal.M;
 import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.domain.grammar.nonterminal.TL;
@@ -20,7 +19,7 @@ public class SemanticAction6 extends SemanticAction {
     private final M m;
     private final TL tl;
     private final T t;
-
+    
     public SemanticAction6(M m, TL tl, T t) {
         super("AS6");
         
@@ -31,12 +30,10 @@ public class SemanticAction6 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        if (tl.isValue()) {
-            t.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(tl.getOperator(), m.getAddress(), tl.getAddress(), t.getAddress(), t.getPosition(), t.getLevel());
-        } else {
-            t.setAddress(m.getAddress());
-        }
+        m.setPosition(t.getPosition());
+        tl.setPosition(t.getPosition());
+        m.setLevel(t.getLevel());
+        tl.setLevel(t.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction7.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction7.java
@@ -5,7 +5,9 @@
  */
 package br.ifmath.compiler.domain.grammar.semanticaction;
 
+
 import br.ifmath.compiler.domain.grammar.nonterminal.M;
+import br.ifmath.compiler.domain.grammar.nonterminal.T;
 import br.ifmath.compiler.domain.grammar.nonterminal.TL;
 import br.ifmath.compiler.infrastructure.compiler.iface.IIntermediateCodeGenerator;
 
@@ -17,22 +19,24 @@ public class SemanticAction7 extends SemanticAction {
 
     private final M m;
     private final TL tl;
-    private final TL tl1;
-    
-    public SemanticAction7(M m, TL tl, TL tl1) {
+    private final T t;
+
+    public SemanticAction7(M m, TL tl, T t) {
         super("AS7");
         
         this.m = m;
         this.tl = tl;
-        this.tl1 = tl1;
+        this.t = t;
     }
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        m.setPosition(tl.getPosition());
-        tl1.setPosition(tl.getPosition());
-        m.setLevel(tl.getLevel());
-        tl1.setLevel(tl.getLevel());
+        if (tl.isValue()) {
+            t.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
+            intermediateCodeGenerator.addNewOperation(tl.getOperator(), m.getAddress(), tl.getAddress(), t.getAddress(), t.getPosition(), t.getLevel());
+        } else {
+            t.setAddress(m.getAddress());
+        }
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction8.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction8.java
@@ -29,15 +29,10 @@ public class SemanticAction8 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-        tl.setValue(true);
-        tl.setOperator("+");
-        
-        if (tl1.isValue()) {
-            tl.setAddress(intermediateCodeGenerator.getNextTemporary().toString());
-            intermediateCodeGenerator.addNewOperation(tl1.getOperator(), m.getAddress(), tl1.getAddress(), tl.getAddress(), tl.getPosition(), tl.getLevel());
-        } else {
-            tl.setAddress(m.getAddress());
-        }
+        m.setPosition(tl.getPosition());
+        tl1.setPosition(tl.getPosition());
+        m.setLevel(tl.getLevel());
+        tl1.setLevel(tl.getLevel());
     }
     
 }

--- a/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction9.java
+++ b/src/main/java/br/ifmath/compiler/domain/grammar/semanticaction/SemanticAction9.java
@@ -29,8 +29,8 @@ public class SemanticAction9 extends SemanticAction {
 
     @Override
     public void executeAction(IIntermediateCodeGenerator intermediateCodeGenerator) {
-       tl.setValue(true);
-        tl.setOperator("-");
+        tl.setValue(true);
+        tl.setOperator("+");
         
         if (tl1.isValue()) {
             tl.setAddress(intermediateCodeGenerator.getNextTemporary().toString());

--- a/src/main/java/br/ifmath/compiler/infrastructure/props/RegexPattern.java
+++ b/src/main/java/br/ifmath/compiler/infrastructure/props/RegexPattern.java
@@ -98,11 +98,11 @@ public enum RegexPattern {
         }
     },
 
-    INVALID_DISTRIBUTIVE_OPERATION {
+    REDUCED_DISTRIBUTIVE_OPERATION {
 
         @Override
         public String toString() {
-            return "[a-zA-Z0-9]\\(";
+            return "(?<![a-zA-Z0-9])([0-9]+[a-zA-Z]|[a-zA-Z]|[0-9]+)\\(";
         }
     };
 

--- a/src/main/java/br/ifmath/compiler/infrastructure/util/MathOperatorUtil.java
+++ b/src/main/java/br/ifmath/compiler/infrastructure/util/MathOperatorUtil.java
@@ -1,6 +1,8 @@
 package br.ifmath.compiler.infrastructure.util;
 
 import br.ifmath.compiler.infrastructure.props.RegexPattern;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *
@@ -45,4 +47,17 @@ public class MathOperatorUtil {
         return Double.parseDouble(multiplier) * Double.parseDouble(coeficient);
     }
 
+    public static String replaceReducedDistributive(String source) {
+        CharSequence inputStr = source;
+        Pattern pattern = Pattern.compile(RegexPattern.REDUCED_DISTRIBUTIVE_OPERATION.toString());
+        Matcher matcher = pattern.matcher(inputStr);
+        int plusSpace = 0;
+        while(matcher.find()){
+            source = source.substring(0, matcher.end() + plusSpace - 1 ) + "*" + source.substring(matcher.end() + plusSpace - 1 );
+            plusSpace++;
+        }
+        
+        return source;
+    }
+    
 }

--- a/src/test/java/br/ifmath/compiler/tests/InvalidStructureErrorCaseTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/InvalidStructureErrorCaseTest.java
@@ -4,7 +4,6 @@ import br.ifmath.compiler.application.Compiler;
 import br.ifmath.compiler.application.ICompiler;
 import br.ifmath.compiler.domain.expertsystem.*;
 import br.ifmath.compiler.domain.expertsystem.linearequation.LinearEquationExpertSystem;
-import br.ifmath.compiler.domain.grammar.InvalidDistributiveOperationException;
 import br.ifmath.compiler.domain.grammar.nonterminal.UnrecognizedStructureException;
 import br.ifmath.compiler.infrastructure.compiler.UnrecognizedLexemeException;
 import org.junit.Before;
@@ -37,7 +36,7 @@ public class InvalidStructureErrorCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -51,7 +50,7 @@ public class InvalidStructureErrorCaseTest {
            compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -79,7 +78,7 @@ public class InvalidStructureErrorCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -93,7 +92,7 @@ public class InvalidStructureErrorCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -107,7 +106,7 @@ public class InvalidStructureErrorCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -121,7 +120,7 @@ public class InvalidStructureErrorCaseTest {
             IAnswer answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -193,7 +192,7 @@ public class InvalidStructureErrorCaseTest {
              compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 
@@ -207,7 +206,7 @@ public class InvalidStructureErrorCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(UnrecognizedStructureException.class));
         }
     }
 }

--- a/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleDistributiveTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleDistributiveTest.java
@@ -281,4 +281,60 @@ public class LinearEquationRuleDistributiveTest {
         assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
         assertEquals(finalStep.getReason(), finalResultExplicationExpected);
     }
+    
+    @Test()
+    public void linear_equation_should_use_distributive_rule_scenery_ten_with_success() {
+        //Arrange
+        String expression = "x+3*(-10)=-x";
+
+        int positionTwo = 1;
+
+        String secondStepValueExpected = "x - 30 =  -x";
+        String lastStepValueExpected = "x = 15";
+
+        // Act
+        IAnswer answer = null;
+        try {
+            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        // Assert
+        Step secondStep = answer.getSteps().get(positionTwo);
+        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
+
+        assertEquals(secondStep.getMathExpression(), secondStepValueExpected);
+        assertEquals(secondStep.getReason(), distributiveExplicationExpected);
+        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
+        assertEquals(finalStep.getReason(), finalResultExplicationExpected);
+    }
+    
+    @Test()
+    public void linear_equation_should_use_distributive_rule_scenery_eleven_with_success() {
+        //Arrange
+        String expression = "x+3*(-10x)=-1";
+
+        int positionTwo = 1;
+
+        String secondStepValueExpected = "x - 30x =  -1";
+        String lastStepValueExpected = "x = 1 / 29";
+
+        // Act
+        IAnswer answer = null;
+        try {
+            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        // Assert
+        Step secondStep = answer.getSteps().get(positionTwo);
+        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
+
+        assertEquals(secondStep.getMathExpression(), secondStepValueExpected);
+        assertEquals(secondStep.getReason(), distributiveExplicationExpected);
+        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
+        assertEquals(finalStep.getReason(), finalResultExplicationExpected);
+    }
 }

--- a/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleIsolateAndSumTermsTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleIsolateAndSumTermsTest.java
@@ -4,7 +4,6 @@ import br.ifmath.compiler.application.Compiler;
 import br.ifmath.compiler.application.ICompiler;
 import br.ifmath.compiler.domain.expertsystem.*;
 import br.ifmath.compiler.domain.expertsystem.linearequation.LinearEquationExpertSystem;
-import br.ifmath.compiler.domain.grammar.InvalidDistributiveOperationException;
 import br.ifmath.compiler.domain.grammar.nonterminal.UnrecognizedStructureException;
 import br.ifmath.compiler.infrastructure.compiler.UnrecognizedLexemeException;
 import org.junit.Before;

--- a/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleNegativeVariableTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationRuleNegativeVariableTest.java
@@ -88,7 +88,7 @@ public class LinearEquationRuleNegativeVariableTest {
         String expression = "5 + 6= -4x";
 
         int positionThree = 2;
-        String lastStepValueExpected = "x = 11 / 4";
+        String lastStepValueExpected = "x =  -11 / 4";
 
         // Act
         IAnswer answer = null;

--- a/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationSucessCaseTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationSucessCaseTest.java
@@ -380,5 +380,26 @@ public class LinearEquationSucessCaseTest {
             assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
         }
     }
+    
+    @Test()
+    public void linear_equation_should_sucess_case_scenery_twenty_two_with_success() {
+        //Arrange
+        String expression = "2y + 3 = -7";
+
+        String lastStepValueExpected = "y = 2";
+
+        // Act
+        IAnswer answer = null;
+        try {
+            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        // Assert
+        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
+
+        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
+        assertEquals(finalStep.getReason(), finalResultExplicationExpected);
+    }
 
 }

--- a/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationSucessCaseTest.java
+++ b/src/test/java/br/ifmath/compiler/tests/linearequation/LinearEquationSucessCaseTest.java
@@ -4,7 +4,6 @@ import br.ifmath.compiler.application.Compiler;
 import br.ifmath.compiler.application.ICompiler;
 import br.ifmath.compiler.domain.expertsystem.*;
 import br.ifmath.compiler.domain.expertsystem.linearequation.LinearEquationExpertSystem;
-import br.ifmath.compiler.domain.grammar.InvalidDistributiveOperationException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -84,7 +83,7 @@ public class LinearEquationSucessCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -98,7 +97,7 @@ public class LinearEquationSucessCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -112,7 +111,7 @@ public class LinearEquationSucessCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -150,14 +149,12 @@ public class LinearEquationSucessCaseTest {
         //Arrange
         String expression = "raiz(2x;4)=(7+g)";
 
-        String lastStepValueExpected = "x = 1";
-
         // Act
         try {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -166,15 +163,12 @@ public class LinearEquationSucessCaseTest {
         //Arrange
         String expression = "log(2x;4)=-7";
 
-        String lastStepValueExpected = "2x log 4 =  -7";
-
         // Act
-        IAnswer answer = null;
         try {
-            compiler.analyse(expertSystem, AnswerType.BEST, expression);
+            Object result = compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -182,14 +176,13 @@ public class LinearEquationSucessCaseTest {
     public void  linear_equation_should_sucess_case_scenery_eleven_with_fail()  {
         //Arrange
         String expression = "log10(raizq(3x+2))=-7";
-        String lastStepValueExpected = "3x + 2 raizq 2 log10 10 =  -7";
 
         // Act
         try {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -203,30 +196,23 @@ public class LinearEquationSucessCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
     @Test()
-    public void linear_equation_should_sucess_case_scenery_thirteen_with_success() {
+    public void linear_equation_should_sucess_case_scenery_thirteen_with_fail() {
         //Arrange
         String expression = "x^2 + 3x = -5,4";
-
-        String lastStepValueExpected = "x ^ 2 + 3x =  -5,4";
 
         // Act
         IAnswer answer = null;
         try {
-            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
+            compiler.analyse(expertSystem, AnswerType.BEST, expression);
+            fail();
         } catch (Exception e) {
-            fail(e.getMessage());
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
-
-        // Assert
-        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
-
-        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
-        assertEquals(finalStep.getReason(), "Equação inicial.");
     }
 
     @Test()
@@ -344,13 +330,20 @@ public class LinearEquationSucessCaseTest {
         //Arrange
         String expression = "2x(3 - 1)=0";
 
+        String lastStepValueExpected = "x = 0";
+
         // Act
+        IAnswer answer = null;
         try {
-            compiler.analyse(expertSystem, AnswerType.BEST, expression);
-            fail();
+            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            fail(e.getMessage());
         }
+        
+        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
+
+        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
+        assertEquals(finalStep.getReason(), finalResultExplicationExpected);
     }
 
     @Test()
@@ -363,7 +356,7 @@ public class LinearEquationSucessCaseTest {
             compiler.analyse(expertSystem, AnswerType.BEST, expression);
             fail();
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            assertThat(e, instanceOf(InvalidAlgebraicExpressionException.class));
         }
     }
 
@@ -371,14 +364,20 @@ public class LinearEquationSucessCaseTest {
     public void linear_equation_should_sucess_case_scenery_twenty_one_with_success() {
         //Arrange
         String expression = "x(3 - 1)=0";
+        String lastStepValueExpected = "x = 0";
 
         // Act
+        IAnswer answer = null;
         try {
-            compiler.analyse(expertSystem, AnswerType.BEST, expression);
-            fail();
+            answer = compiler.analyse(expertSystem, AnswerType.BEST, expression);
         } catch (Exception e) {
-            assertThat(e, instanceOf(InvalidDistributiveOperationException.class));
+            fail(e.getMessage());
         }
+        
+        Step finalStep = answer.getSteps().get(answer.getSteps().size() - 1);
+
+        assertEquals(finalStep.getMathExpression(), lastStepValueExpected);
+        assertEquals(finalStep.getReason(), finalResultExplicationExpected);
     }
     
     @Test()


### PR DESCRIPTION
This pull request contains the following changes:
- Adding * operator when the expression is an reduced distributive. Ex: `2(x + 2)` -> `2*(x + 2)`;
- Improving the regular expression that recognize reduced distributives. It was recognized as reduced distributive any operation that used parentheses (log, raiz, ...);
- Updating GLC of compile to recognize expression with comparison. For doing it, it was necessary to add an new non terminal called `E'`, that make possible turn the comparison optional. Ex: the expression `x + 1 + 2x^2` will be recognized by compiler;
- Fixing a bug when distributive with only one term inside parentheses;
- Fixing a bug with isolate term rule of linear equation that it has been turned the term negative when it does not necessary.
- Improving some unit tests;
